### PR TITLE
Upgrade eslint and now perform linting of nested files

### DIFF
--- a/projects/code-from-asset-helper/README.md
+++ b/projects/code-from-asset-helper/README.md
@@ -1,11 +1,10 @@
 # Code from Asset Helper
 
-A helper to build, bundle and copy a lambda or AppSync function to the Amplify assets directory. 
+A helper to build, bundle and copy a lambda or AppSync function to the Amplify assets directory.
 
 ## Installation
 
 `npm install --save-dev @amplify-playground/code-from-asset-helper`
-
 
 ## Basic Usage
 
@@ -14,70 +13,66 @@ A helper to build, bundle and copy a lambda or AppSync function to the Amplify a
 The example below defines an Amplify backend and builds and bundles the function `my-custom-function.lambda.ts` using esbuild.
 
 ```ts
-
-import { BuildMode, lambdaCodeFromAssetHelper } from '@amplify-playground/code-from-asset-helper';
-import { defineBackend } from '@aws-amplify/backend';
+import {
+  BuildMode,
+  lambdaCodeFromAssetHelper,
+} from "@amplify-playground/code-from-asset-helper";
+import { defineBackend } from "@aws-amplify/backend";
 import {
   Function as LambdaFunction,
   Runtime as LambdaRuntime,
-} from 'aws-cdk-lib/aws-lambda';
-import path from 'path';
+} from "aws-cdk-lib/aws-lambda";
+import path from "path";
 
 const backend = defineBackend({
   //..
 });
 
-const stack = backend.createStack('MyCustomStack');
+const stack = backend.createStack("MyCustomStack");
 
-const buildConfig: AssetHelperConfig = { 
-  buildMode: BuildMode.Esbuild
+const buildConfig: AssetHelperConfig = {
+  buildMode: BuildMode.Esbuild,
 };
 
-const myLambda = new LambdaFunction(stack, 'MyCustomFunction', {
-  handler: 'index.handler',
+const myLambda = new LambdaFunction(stack, "MyCustomFunction", {
+  handler: "index.handler",
   code: lambdaCodeFromAssetHelper(
-    path.resolve('amplify/functions/my-custom-function.lambda.ts'),
+    path.resolve("amplify/functions/my-custom-function.lambda.ts"),
     buildConfig
   ),
   runtime: LambdaRuntime.NODEJS_20_X,
 });
-
-
 ```
 
 ## Configuration
 
 Disable building and copy file as is:
 
-```ts 
-const buildConfig: AssetHelperConfig = { 
-  buildMode: BuildMode.Off
-}
-
+```ts
+const buildConfig: AssetHelperConfig = {
+  buildMode: BuildMode.Off,
+};
 ```
 
 Transpile using the TypeScript transpiler:
 
-```ts 
-const buildConfig: AssetHelperConfig = { 
+```ts
+const buildConfig: AssetHelperConfig = {
   buildMode: BuildMode.Typescript,
-  tsTranspileOptions: {} // Optional
-}
-
+  tsTranspileOptions: {}, // Optional
+};
 ```
 
 Build and bundle to a single file using esbuild (recommended):
 
-```ts 
-const buildConfig: AssetHelperConfig = { 
+```ts
+const buildConfig: AssetHelperConfig = {
   buildMode: BuildMode.Esbuild,
-  esBuildOptions: {} // Optional
-}
-
+  esBuildOptions: {}, // Optional
+};
 ```
-### AppSync functions
 
-The path to your `tsconfig.json` must be provided when building AppSync resolver functions. This allows linting against AppSync resolver functions' rules. 
+### AppSync functions
 
 The following example configures a pipeline resolver for a field `createTodo` :
 
@@ -85,37 +80,187 @@ The following example configures a pipeline resolver for a field `createTodo` :
 //...
 
 const backend = defineBackend({
-  data
+  data,
 });
 
 const buildConfig: AppSyncAssetHelperConfigES = {
   buildMode: BuildMode.Esbuild,
-  tsConfig: path.join('amplify/data', 'tsconfig.json'),
 };
 
-backend.data.addResolver('createTodo', {
-    fieldName: 'createTodo',
-    typeName: 'Mutation',
-    runtime: FunctionRuntime.JS_1_0_0,
-    code: Code.fromAsset(
-            //this function is plain js
-            path.join(__dirnameCommon, 'pipeline-handler.resolver.js') 
-    ),
-    pipelineConfig: [
-      new AppsyncFunction(stack, 'TodoCreate', {
-        api: backend.data.resources.graphqlApi,
-        dataSource: todoDataSource,
-        name: 'TodoCreate',
-        code: await appSyncCodeFromAssetHelper(
-          path.join(__dirname, 'todo-create.resolver.ts'), 
-          buildConfig
-        ),
-        runtime: FunctionRuntime.JS_1_0_0,
-      })
-    ]
-  });
-
+backend.data.addResolver("createTodo", {
+  fieldName: "createTodo",
+  typeName: "Mutation",
+  runtime: FunctionRuntime.JS_1_0_0,
+  code: Code.fromAsset(
+    //this function is plain js
+    path.join(__dirnameCommon, "pipeline-handler.resolver.js")
+  ),
+  pipelineConfig: [
+    new AppsyncFunction(stack, "TodoCreate", {
+      api: backend.data.resources.graphqlApi,
+      dataSource: todoDataSource,
+      name: "TodoCreate",
+      code: await appSyncCodeFromAssetHelper(
+        path.join(__dirname, "todo-create.resolver.ts"),
+        buildConfig
+      ),
+      runtime: FunctionRuntime.JS_1_0_0,
+    }),
+  ],
+});
 ```
+
+### Linting
+
+ESLint is called on the target source file as well as each its nested import files. Linting rules are picked up from your eslint configuration file (eg. eslint.config.mjs) in your project. Assuming that you are working with Lambda (node) and AppSync resolvers (AppSync_JS) then you will want a set of rules that constrains your code to what is available to the respective runtime environments.
+
+The following configures linting for a project that contains source for both environments. As such, the project uses the convention of suffixing AppSync resolvers with `*.resolver.ts` and Lambda code with `*.lambda.ts`. This allows the eslint rules to apply the contraints appropriately.
+
+The config below also bans importing `*.resolver.ts` code in `*.lambda.ts` scripts and vice versa.
+
+With this config in your project, you can get live linting in your IDE as well as when Amplify builds your code imported using the code from asset helper functions.
+
+```typescript
+//File: eslint.config.mjs
+import eslint from "@eslint/js";
+import typescriptEslintParser from "@typescript-eslint/parser";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+// The AWS AppSync plugin that provides the rules for AppSync_JS:
+import appsyncPlugin from "@aws-appsync/eslint-plugin";
+
+export default tseslint.config(
+  {
+    ignores: [...ignoreFiles],
+  },
+  {
+    languageOptions: {
+      parser: typescriptEslintParser,
+      sourceType: "module",
+      globals: {
+        ...globals.node,
+      },
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.mjs", "./eslint.config.mjs"],
+        },
+      },
+    },
+  },
+  {
+    // :: Main Source Files
+    extends: [
+      eslint.configs.recommended,
+      tseslint.configs.recommendedTypeChecked,
+    ],
+
+    rules: {
+      ...rulesNoUnusedVarsConfig,
+    },
+    files: ["**/*.ts", "eslint.config.mjs"],
+    ignores: [...ignoreFiles],
+  },
+  {
+    // :: Resolver files
+    extends: [
+      eslint.configs.recommended,
+      tseslint.configs.recommendedTypeChecked,
+      appsyncPlugin.configs.recommended,
+    ],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["aws-cdk-lib", "aws-cdk-lib/*"],
+              message: "usage of appsync lambda libraries is disallowed.",
+              allowTypeImports: true,
+            },
+            {
+              group: ["*.lambda"],
+              message: "usage of .lambda utilities is not allowed",
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+      ...rulesNoUnusedVarsConfig,
+    },
+    files: ["**/*.resolver.ts"],
+    ignores: [...ignoreFiles, "**/*.test.ts", "**/*.lambda.ts"],
+  },
+  {
+    // :: Lambda files
+    extends: [
+      eslint.configs.recommended,
+      tseslint.configs.recommendedTypeChecked,
+    ],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["@aws-appsync/utils", "@aws-appsync/utils/*"],
+              message:
+                "usage of appsync utils in a lambda function is disallowed.",
+              allowTypeImports: true,
+            },
+            {
+              group: ["*.resolver"],
+              message: "usage of .resolver utilities is not allowed",
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+      ...rulesNoUnusedVarsConfig,
+    },
+    files: ["**/*.lambda.ts"],
+    ignores: [...ignoreFiles, "**/*.test.ts", "**/*.resolver.ts"],
+  },
+  {
+    // :: Tests
+    extends: [eslint.configs.recommended, tseslint.configs.recommended],
+    rules: {
+      ...rulesNoUnusedVarsConfig,
+    },
+    files: ["**/*.{.test.ts}"],
+    ignores: [...ignoreFiles],
+  }
+);
+
+// Ignore Files
+const ignoreFiles = [
+  "**/build/**",
+  "**/dist/**",
+  "**/node_modules/**",
+  "**/.amplify/",
+  "**/codegen-out/**",
+  "**/*.generated.ts",
+];
+
+// (Optional) Rule Override: allow unusued vars that are explicitly prefixed with `_unused`
+const rulesNoUnusedVarsConfig = {
+  "@typescript-eslint/no-unused-vars": [
+    2,
+    {
+      argsIgnorePattern: "^_unused",
+      varsIgnorePattern: "^_unused",
+      caughtErrorsIgnorePattern: "^_unused",
+    },
+  ],
+};
+```
+
+## Breaking Changes
+
+### v1.x > v2.x:
+
+- Upgrades eslint from v8 to v9. Eslint's FlatConfig is now required.
+
 ## License
 
 Apache License 2.0

--- a/projects/code-from-asset-helper/README.md
+++ b/projects/code-from-asset-helper/README.md
@@ -114,7 +114,7 @@ backend.data.addResolver("createTodo", {
 
 ESLint is called on the target source file as well as each its nested import files. Linting rules are picked up from your eslint configuration file (eg. eslint.config.mjs) in your project. Assuming that you are working with Lambda (node) and AppSync resolvers (AppSync_JS) then you will want a set of rules that constrains your code to what is available to the respective runtime environments.
 
-The following configures linting for a project that contains source for both environments. As such, the project uses the convention of suffixing AppSync resolvers with `*.resolver.ts` and Lambda code with `*.lambda.ts`. This allows the eslint rules to apply the contraints appropriately.
+The following configures linting for a project that contains source for both environments. As such, the project uses the convention of suffixing AppSync resolvers with `*.resolver.ts` and Lambda code with `*.lambda.ts`. This allows the eslint rules to apply the contraints appropriately. (For your project, you may choose instead to identify your AppSync/Lambda code based on directory path. Modify the glob patterns as necessary to reflect this.)
 
 The config below also bans importing `*.resolver.ts` code in `*.lambda.ts` scripts and vice versa.
 
@@ -260,6 +260,7 @@ const rulesNoUnusedVarsConfig = {
 ### v1.x > v2.x:
 
 - Upgrades eslint from v8 to v9. Eslint's FlatConfig is now required.
+- The code from asset helpers no longer include the default configs but instead relies on your eslint config file (eslint.config.mjs).
 
 ## License
 

--- a/projects/code-from-asset-helper/eslint.config.mjs
+++ b/projects/code-from-asset-helper/eslint.config.mjs
@@ -1,10 +1,68 @@
-import pluginJs from "@eslint/js";
+import eslint from "@eslint/js";
+import typescriptEslintParser from "@typescript-eslint/parser";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
-export default [
-  { files: ["**/*.{js,mjs,cjs,ts}"] },
-  { languageOptions: { globals: globals.browser } },
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
-];
+import appsyncPlugin from "@aws-appsync/eslint-plugin";
+
+export default tseslint.config(
+  {
+    extends: [
+      eslint.configs.recommended,
+      tseslint.configs.recommendedTypeChecked,
+    ],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.mjs"],
+        },
+        // tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    // :: Resolver files
+    extends: [
+      eslint.configs.recommended,
+      tseslint.configs.recommendedTypeChecked, // @TODO: upgrade to strictTypeChecked
+      appsyncPlugin.configs.recommended,
+    ],
+    languageOptions: {
+      parser: typescriptEslintParser,
+      sourceType: "module",
+      globals: {
+        ...globals.node,
+      },
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.mjs", "./eslint.config.mjs"],
+        },
+        // tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["aws-cdk-lib", "aws-cdk-lib/*"],
+              message: "usage of appsync lambda libraries is disallowed.",
+              allowTypeImports: true,
+            },
+            {
+              group: ["*.lambda"],
+              message: "usage of .lambda utilities is not allowed",
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+    },
+    files: ["**/*.resolver.ts"],
+    ignores: ["**/*.test.ts", "**/*.generated.ts", "**/*.lambda.ts"],
+  }
+);

--- a/projects/code-from-asset-helper/eslint.config.mjs
+++ b/projects/code-from-asset-helper/eslint.config.mjs
@@ -1,11 +1,10 @@
-import globals from "globals";
 import pluginJs from "@eslint/js";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 
-
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {languageOptions: { globals: globals.browser }},
+  { files: ["**/*.{js,mjs,cjs,ts}"] },
+  { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
 ];

--- a/projects/code-from-asset-helper/lib/backend.utils.ts
+++ b/projects/code-from-asset-helper/lib/backend.utils.ts
@@ -296,10 +296,7 @@ export const esbuildBuilding = (options: {
   };
 };
 
-export type EsLintingArgsType = (
-  | EsLintingFilesArgsType
-  | EsLintingTextArgsType
-) & { lintJs: boolean };
+export type EsLintingArgsType = EsLintingFilesArgsType | EsLintingTextArgsType;
 
 export type EsLintingFilesArgsType = {
   source: "appsync" | "lambda";
@@ -319,7 +316,7 @@ export const esLinting = async (
   //setup base config for appsync or lambda
 
   const eslint = new ESLint({
-    ...getEslintBaseConfig(args.source, args.lintJs),
+    ...getEslintBaseConfig(args.source),
     overrideConfig: args.overrideEslintConfig,
   });
 
@@ -367,16 +364,10 @@ export const esLinting = async (
   return false;
 };
 
-function getEslintBaseConfig(
-  source: "appsync" | "lambda",
-  lintJs?: boolean
-): ESLint.Options {
-  const baseConfigs =
-    lintJs === true
-      ? [eslint.configs.recommended]
-      : (tseslint.config(
-          ...[eslint.configs.recommended, tseslint.configs.recommended]
-        ) as Linter.Config[]);
+function getEslintBaseConfig(source: "appsync" | "lambda"): ESLint.Options {
+  const baseConfigs = tseslint.config(
+    ...[eslint.configs.recommended, tseslint.configs.recommended]
+  ) as Linter.Config[];
 
   return source === "appsync"
     ? {
@@ -447,7 +438,6 @@ async function build(
     codeType,
     sourceFilePath,
     config,
-    lintJs: false,
     debugSource: sourceFilePath,
   });
 
@@ -547,7 +537,7 @@ async function build(
 type LintHelperArgsType = (
   | LintHelperArgsForFileType
   | LintHelperArgsForTextType
-) & { lintJs: boolean; debugSource: string };
+) & { debugSource: string };
 
 type LintHelperArgsForFileType = {
   codeType: string;
@@ -578,7 +568,7 @@ export async function lintNestedFiles(
         codeType,
         sourceText: builtFileText,
         config,
-        lintJs: false,
+
         debugSource: nestedImport,
       });
     } catch (e: unknown) {
@@ -609,7 +599,7 @@ async function lintHelper(args: LintHelperArgsType) {
     const result = await esLinting({
       source: "appsync",
       overrideEslintConfig: args.config.overrideEslintConfig,
-      lintJs: args.lintJs,
+
       ...lintSourceConfig,
     });
 
@@ -621,7 +611,7 @@ async function lintHelper(args: LintHelperArgsType) {
     const result = await esLinting({
       source: "lambda",
       overrideEslintConfig: args.config.overrideEslintConfig,
-      lintJs: args.lintJs,
+
       ...lintSourceConfig,
     });
 

--- a/projects/code-from-asset-helper/lib/backend.utils.ts
+++ b/projects/code-from-asset-helper/lib/backend.utils.ts
@@ -41,6 +41,8 @@ import globals from "globals";
  *
  * @param {BuildMode} config.tsTranspileOptions - The build options for TypeScript transpiler. Only used if buildMode is set to Typescript.
  *
+ * @param {BuildMode} config.overrideEslintConfig - These options are passed to ESLint.Options.overrideConfig
+ *
  * @returns A lambda Code object (aliased as LambdaCode)
  */
 export async function lambdaCodeFromAssetHelper(

--- a/projects/code-from-asset-helper/lib/backend.utils.ts
+++ b/projects/code-from-asset-helper/lib/backend.utils.ts
@@ -298,7 +298,10 @@ export const esbuildBuilding = (options: {
   };
 };
 
-export type EsLintingArgsType = EsLintingFilesArgsType | EsLintingTextArgsType;
+export type EsLintingArgsType = (
+  | EsLintingFilesArgsType
+  | EsLintingTextArgsType
+) & { debugSource: string };
 
 export type EsLintingFilesArgsType = {
   source: "appsync" | "lambda";
@@ -353,7 +356,7 @@ export const esLinting = async (
       if (m.severity) errorMessage += `Severity: ${m.severity}\n`;
       if (m.message) errorMessage += `Message: ${m.message}\n`;
       if (m.line)
-        errorMessage += `Location: line ${m.line}:${m.column} ${
+        errorMessage += `Location: ${args.debugSource}:${m.line}:${m.column} ${
           m.endLine && m.endColumn ? "to " + m.endLine + ":" + m.endColumn : ""
         }\n`;
       if (m.fix) errorMessage += `Fix: ${m.fix.text}.`;
@@ -608,24 +611,24 @@ async function lintHelper(args: LintHelperArgsType) {
     const result = await esLinting({
       source: "appsync",
       overrideEslintConfig: args.config.overrideEslintConfig,
-
+      debugSource: args.debugSource,
       ...lintSourceConfig,
     });
 
     if (result !== false) {
-      const errorMessage = `The AppSync source file was not built successfully (2): ${args.debugSource}\n\n${result}\n\n`;
+      const errorMessage = `The AppSync source file was not built successfully: ${args.debugSource}\n\n${result}\n\n`;
       throw new Error(errorMessage);
     }
   } else {
     const result = await esLinting({
       source: "lambda",
       overrideEslintConfig: args.config.overrideEslintConfig,
-
+      debugSource: args.debugSource,
       ...lintSourceConfig,
     });
 
     if (result !== false) {
-      const errorMessage = `The Lambda source file was not built successfully (3): ${args.debugSource}\n\n${result}\n\n`;
+      const errorMessage = `The Lambda source file was not built successfully: ${args.debugSource}\n\n${result}\n\n`;
       throw new Error(errorMessage);
     }
   }

--- a/projects/code-from-asset-helper/package.json
+++ b/projects/code-from-asset-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-playground/code-from-asset-helper",
-  "version": "1.2.0-alpha.20",
+  "version": "1.2.0-alpha.22",
   "description": "A helper to build, bundle and copy a lambda or AppSync function to the Amplify assets directory.",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/projects/code-from-asset-helper/package.json
+++ b/projects/code-from-asset-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-playground/code-from-asset-helper",
-  "version": "1.2.0-alpha.23",
+  "version": "1.2.0-alpha.24",
   "description": "A helper to build, bundle and copy a lambda or AppSync function to the Amplify assets directory.",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/projects/code-from-asset-helper/package.json
+++ b/projects/code-from-asset-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-playground/code-from-asset-helper",
-  "version": "1.2.0-alpha.22",
+  "version": "1.2.0-alpha.23",
   "description": "A helper to build, bundle and copy a lambda or AppSync function to the Amplify assets directory.",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/projects/code-from-asset-helper/package.json
+++ b/projects/code-from-asset-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-playground/code-from-asset-helper",
-  "version": "1.1.1",
+  "version": "1.2.0-alpha.20",
   "description": "A helper to build, bundle and copy a lambda or AppSync function to the Amplify assets directory.",
   "main": "dist/index.js",
   "type": "commonjs",
@@ -41,22 +41,20 @@
   },
   "devDependencies": {
     "@aws-appsync/utils": "^1.12.0",
-    "@eslint/js": "^9.17.0",
-    "@types/eslint": "^8.56.12",
-    "@types/node": "^20.17.11",
-    "@typescript-eslint/parser": "^8.19.0",
-    "aws-cdk-lib": "^2.147.1",
-    "eslint": "^8.57.1",
+    "@eslint/js": "^9.19.0",
+    "@types/node": "^22.12.0",
+    "aws-cdk-lib": "^2.177.0",
+    "eslint": "^9.19.0",
     "globals": "^15.14.0",
-    "typescript": "^5.7.2",
-    "typescript-eslint": "^8.19.0",
-    "vitest": "^2.1.8"
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.22.0",
+    "vitest": "^3.0.4"
   },
   "peerDependencies": {
-    "@aws-appsync/eslint-plugin": "^1.6.0",
-    "aws-cdk-lib": "^2.147.1",
-    "esbuild": "^0.21.5",
+    "@aws-appsync/eslint-plugin": "^2.0.1",
+    "aws-cdk-lib": "^2.177.0",
+    "esbuild": "^0.24.2",
     "esbuild-plugin-eslint": "^0.3.12",
-    "eslint": "^8.57.1"
+    "eslint": "^9.19.0"
   }
 }

--- a/projects/code-from-asset-helper/package.json
+++ b/projects/code-from-asset-helper/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@amplify-playground/code-from-asset-helper",
-  "version": "1.2.0-alpha.24",
+  "version": "2.0.0-alpha.1",
   "description": "A helper to build, bundle and copy a lambda or AppSync function to the Amplify assets directory.",
   "main": "dist/index.js",
-  "type": "commonjs",
+  "type": "module",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
@@ -42,7 +42,10 @@
   "devDependencies": {
     "@aws-appsync/utils": "^1.12.0",
     "@eslint/js": "^9.19.0",
+    "@tsconfig/node20": "^20.1.4",
     "@types/node": "^22.12.0",
+    "@typescript-eslint/parser": "^8.23.0",
+    "@vitest/coverage-v8": "^3.0.4",
     "aws-cdk-lib": "^2.177.0",
     "eslint": "^9.19.0",
     "globals": "^15.14.0",

--- a/projects/code-from-asset-helper/tests/__snapshots__/backend.utils.test.ts.snap
+++ b/projects/code-from-asset-helper/tests/__snapshots__/backend.utils.test.ts.snap
@@ -1,0 +1,139 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`appsync builder > esbuild should detect errors in nested files 1`] = `
+[Error: 2 nested file(s) have errors. 
+
+ 
+The AppSync source file was not built successfully: tests/helpers.ts
+
+3 linting error(s) found:: 
+
+:: Lint Rule Error ::
+Rule: @typescript-eslint/no-explicit-any
+Severity: 2
+Message: Unexpected any. Specify a different type.
+Location: tests/helpers.ts:6:13 to 6:16
+Suggestion(s): 
+  Use \`unknown\` instead, this will force you to explicitly, and safely assert the type is correct. Col 256-259 'unknown'
+  Use \`never\` instead, this is useful when instantiating generic type parameters that you don't need to know the type of. Col 256-259 'never'.
+
+:: Lint Rule Error ::
+Rule: @typescript-eslint/no-unsafe-member-access
+Severity: 2
+Message: Unsafe member access .sub on an \`any\` value.
+Location: tests/helpers.ts:8:28 to 8:31
+
+
+:: Lint Rule Error ::
+Rule: @typescript-eslint/no-unsafe-member-access
+Severity: 2
+Message: Unsafe member access .username on an \`any\` value.
+Location: tests/helpers.ts:8:44 to 8:52
+
+
+
+
+
+
+
+
+The AppSync source file was not built successfully: tests/utils.fail.resolver.ts
+
+3 linting error(s) found:: 
+
+:: Lint Rule Error ::
+Rule: @aws-appsync/no-async
+Severity: 2
+Message: Async functions are not supported.
+Location: tests/utils.fail.resolver.ts:1:8 to 4:2
+
+
+:: Lint Rule Error ::
+Rule: @typescript-eslint/require-await
+Severity: 2
+Message: Async function 'addition' has no 'await' expression.
+Location: tests/utils.fail.resolver.ts:1:8 to 1:31
+Suggestion(s): 
+  Remove 'async'. Col 7-69 'function addition(a: number, b: number): number'.
+
+:: Lint Rule Error ::
+Rule: @typescript-eslint/no-unused-vars
+Severity: 2
+Message: 'c' is assigned a value but never used.
+Location: tests/utils.fail.resolver.ts:2:9 to 2:10
+
+
+
+
+
+]
+`;
+
+exports[`appsync builder > full asset helper should detect lint errors 1`] = `
+[Error: 2 nested file(s) have errors. 
+
+ 
+The AppSync source file was not built successfully: tests/helpers.ts
+
+3 linting error(s) found:: 
+
+:: Lint Rule Error ::
+Rule: @typescript-eslint/no-explicit-any
+Severity: 2
+Message: Unexpected any. Specify a different type.
+Location: tests/helpers.ts:6:13 to 6:16
+Suggestion(s): 
+  Use \`unknown\` instead, this will force you to explicitly, and safely assert the type is correct. Col 256-259 'unknown'
+  Use \`never\` instead, this is useful when instantiating generic type parameters that you don't need to know the type of. Col 256-259 'never'.
+
+:: Lint Rule Error ::
+Rule: @typescript-eslint/no-unsafe-member-access
+Severity: 2
+Message: Unsafe member access .sub on an \`any\` value.
+Location: tests/helpers.ts:8:28 to 8:31
+
+
+:: Lint Rule Error ::
+Rule: @typescript-eslint/no-unsafe-member-access
+Severity: 2
+Message: Unsafe member access .username on an \`any\` value.
+Location: tests/helpers.ts:8:44 to 8:52
+
+
+
+
+
+
+
+
+The AppSync source file was not built successfully: tests/utils.fail.resolver.ts
+
+3 linting error(s) found:: 
+
+:: Lint Rule Error ::
+Rule: @aws-appsync/no-async
+Severity: 2
+Message: Async functions are not supported.
+Location: tests/utils.fail.resolver.ts:1:8 to 4:2
+
+
+:: Lint Rule Error ::
+Rule: @typescript-eslint/require-await
+Severity: 2
+Message: Async function 'addition' has no 'await' expression.
+Location: tests/utils.fail.resolver.ts:1:8 to 1:31
+Suggestion(s): 
+  Remove 'async'. Col 7-69 'function addition(a: number, b: number): number'.
+
+:: Lint Rule Error ::
+Rule: @typescript-eslint/no-unused-vars
+Severity: 2
+Message: 'c' is assigned a value but never used.
+Location: tests/utils.fail.resolver.ts:2:9 to 2:10
+
+
+
+
+
+]
+`;

--- a/projects/code-from-asset-helper/tests/backend.utils.test.ts
+++ b/projects/code-from-asset-helper/tests/backend.utils.test.ts
@@ -16,21 +16,24 @@ describe("appsync builder", () => {
       "./tests/create-report.fail.resolver.ts"
     );
 
-    expect(async () => {
+    await expect(async () => {
       const lintResult = await esLinting({
         source: "appsync",
         sourceFilePath,
         overrideEslintConfig: {
-          parserOptions: {
-            project: path.resolve("./tests/tsconfig.json"),
+          languageOptions: {
+            parserOptions: {
+              project: path.resolve("./tests/tsconfig.json"),
+            },
           },
         },
+        lintJs: false,
       });
 
       if (lintResult !== false) {
         throw Error(lintResult);
       }
-    }).rejects.toThrow("2 linting error(s)");
+    }).rejects.toThrow("3 linting error(s)");
   });
 
   test("esbuild should create output", async () => {
@@ -44,10 +47,13 @@ describe("appsync builder", () => {
       source: "appsync",
       sourceFilePath,
       overrideEslintConfig: {
-        parserOptions: {
-          project: path.resolve("./tests/tsconfig.json"),
+        languageOptions: {
+          parserOptions: {
+            project: path.resolve("./tests/tsconfig.json"),
+          },
         },
       },
+      lintJs: false,
     });
 
     //AppSync function build
@@ -94,10 +100,13 @@ describe("appsync builder", () => {
       source: "appsync",
       sourceFilePath,
       overrideEslintConfig: {
-        parserOptions: {
-          project: path.resolve("./tests/tsconfig.json"),
+        languageOptions: {
+          parserOptions: {
+            project: path.resolve("./tests/tsconfig.json"),
+          },
         },
       },
+      lintJs: false,
     });
 
     const outFile = tsTranspiling(

--- a/projects/code-from-asset-helper/tests/backend.utils.test.ts
+++ b/projects/code-from-asset-helper/tests/backend.utils.test.ts
@@ -29,7 +29,6 @@ describe("appsync builder", () => {
             },
           },
         },
-        lintJs: false,
       });
 
       if (lintResult !== false) {
@@ -55,7 +54,6 @@ describe("appsync builder", () => {
           },
         },
       },
-      lintJs: false,
     });
 
     //AppSync function build
@@ -108,7 +106,6 @@ describe("appsync builder", () => {
           },
         },
       },
-      lintJs: false,
     });
 
     const outFile = tsTranspiling(
@@ -143,7 +140,6 @@ test("esbuild should detect errors in nested files", async () => {
     source: "appsync",
     sourceFilePath,
     overrideEslintConfig: overrideConfig,
-    lintJs: false,
   });
 
   //AppSync function build

--- a/projects/code-from-asset-helper/tests/backend.utils.test.ts
+++ b/projects/code-from-asset-helper/tests/backend.utils.test.ts
@@ -29,6 +29,7 @@ describe("appsync builder", () => {
             },
           },
         },
+        debugSource: sourceFilePath,
       });
 
       if (lintResult !== false) {
@@ -54,6 +55,7 @@ describe("appsync builder", () => {
           },
         },
       },
+      debugSource: sourceFilePath,
     });
 
     //AppSync function build
@@ -106,6 +108,7 @@ describe("appsync builder", () => {
           },
         },
       },
+      debugSource: sourceFilePath,
     });
 
     const outFile = tsTranspiling(
@@ -140,6 +143,7 @@ test("esbuild should detect errors in nested files", async () => {
     source: "appsync",
     sourceFilePath,
     overrideEslintConfig: overrideConfig,
+    debugSource: sourceFilePath,
   });
 
   //AppSync function build

--- a/projects/code-from-asset-helper/tests/create-report.fail.resolver.ts
+++ b/projects/code-from-asset-helper/tests/create-report.fail.resolver.ts
@@ -1,8 +1,7 @@
-import { Context, util } from '@aws-appsync/utils';
-import { CreateModelMetaData, getLoggedInUserId } from './helpers';
+import { Context, util } from "@aws-appsync/utils";
+import { CreateModelMetaData, getLoggedInUserId } from "./helpers";
 
 export async function request(ctx: Context<{ input: any }>) {
-
   const metaData: CreateModelMetaData = {
     createdBy: await getLoggedInUserId(ctx),
     createdAt: util.time.nowISO8601(),
@@ -11,13 +10,12 @@ export async function request(ctx: Context<{ input: any }>) {
   const values = ctx.args.input;
 
   return {
-    operation: 'PutItem',
+    operation: "PutItem",
     key: util.dynamodb.toMapValues({ id: util.autoId() }),
     attributeValues: util.dynamodb.toMapValues({
       ...values,
-      ...metaData
+      ...metaData,
     }),
-
   };
 }
 

--- a/projects/code-from-asset-helper/tests/create-report.resolver.ts
+++ b/projects/code-from-asset-helper/tests/create-report.resolver.ts
@@ -1,8 +1,7 @@
-import { Context, util } from '@aws-appsync/utils';
-import { CreateModelMetaData, getLoggedInUserId } from './helpers';
+import { Context, util } from "@aws-appsync/utils";
+import { CreateModelMetaData, getLoggedInUserId } from "./helpers";
 
 export function request(ctx: Context<{ input: any }>) {
-
   const metaData: CreateModelMetaData = {
     createdBy: getLoggedInUserId(ctx),
     createdAt: util.time.nowISO8601(),
@@ -11,13 +10,12 @@ export function request(ctx: Context<{ input: any }>) {
   const values = ctx.args.input;
 
   return {
-    operation: 'PutItem',
+    operation: "PutItem",
     key: util.dynamodb.toMapValues({ id: util.autoId() }),
     attributeValues: util.dynamodb.toMapValues({
       ...values,
-      ...metaData
+      ...metaData,
     }),
-
   };
 }
 

--- a/projects/code-from-asset-helper/tests/create-report.resolver.ts
+++ b/projects/code-from-asset-helper/tests/create-report.resolver.ts
@@ -1,13 +1,16 @@
 import { Context, util } from "@aws-appsync/utils";
 import { CreateModelMetaData, getLoggedInUserId } from "./helpers";
+import { addition } from "./utils.fail.resolver";
 
-export function request(ctx: Context<{ input: any }>) {
+export function request(ctx: Context<{ input: object }>) {
   const metaData: CreateModelMetaData = {
     createdBy: getLoggedInUserId(ctx),
     createdAt: util.time.nowISO8601(),
   };
 
   const values = ctx.args.input;
+
+  console.log(addition(1, 2));
 
   return {
     operation: "PutItem",

--- a/projects/code-from-asset-helper/tests/create-report.resolver.ts
+++ b/projects/code-from-asset-helper/tests/create-report.resolver.ts
@@ -1,6 +1,6 @@
 import { Context, util } from "@aws-appsync/utils";
 import { CreateModelMetaData, getLoggedInUserId } from "./helpers";
-import { addition } from "./utils.fail.resolver";
+import { addition } from "./utils.fail.resolver"; // This nested function should fail linting
 
 export function request(ctx: Context<{ input: object }>) {
   const metaData: CreateModelMetaData = {
@@ -22,7 +22,9 @@ export function request(ctx: Context<{ input: object }>) {
   };
 }
 
-export function response(ctx: Context) {
+export function response(
+  ctx: Context<unknown, Record<string, unknown>, undefined, undefined, unknown>
+) {
   if (ctx.error) {
     util.error(ctx.error.message, ctx.error.type);
   }

--- a/projects/code-from-asset-helper/tests/helpers.ts
+++ b/projects/code-from-asset-helper/tests/helpers.ts
@@ -1,22 +1,23 @@
-import { AppSyncIdentityCognito, Context, util } from '@aws-appsync/utils';
-import { CfnDataSource, CfnGraphQLApi } from 'aws-cdk-lib/aws-appsync';
-import { CfnTable } from 'aws-cdk-lib/aws-dynamodb';
+import { AppSyncIdentityCognito, Context, util } from "@aws-appsync/utils";
+import { CfnDataSource, CfnGraphQLApi } from "aws-cdk-lib/aws-appsync";
+import { CfnTable } from "aws-cdk-lib/aws-dynamodb";
 
-export const isAppSyncIdentityCognito = (identity: any): identity is AppSyncIdentityCognito => {
+export const isAppSyncIdentityCognito = (
+  identity: any
+): identity is AppSyncIdentityCognito => {
   if (identity && identity.sub && identity.username) {
     return true;
   }
 
   return false;
-}
+};
 
 export function getLoggedInUserId(ctx: Context) {
-
   if (isAppSyncIdentityCognito(ctx.identity)) {
     return ctx.identity.sub;
   }
 
-  util.error('NotCognitoIdentity: Not a cognito identity'); // AppSync_JS does not support throwing Error.
+  util.error("NotCognitoIdentity: Not a cognito identity"); // AppSync_JS does not support throwing Error.
 }
 
 export interface ModelMetaData {
@@ -37,21 +38,25 @@ export interface UpdateModelMetaData {
   updatedAt: string;
 }
 
-export function addResourceTags(cfnResource: CfnTable | CfnGraphQLApi | CfnDataSource) {
-
-  cfnResource.addPropertyOverride('Tags', [
+export function addResourceTags(
+  cfnResource: CfnTable | CfnGraphQLApi | CfnDataSource
+) {
+  cfnResource.addPropertyOverride("Tags", [
     {
-      Key: 'ApplicationName',
-      Value: 'CrowdPowered'
-    }
+      Key: "ApplicationName",
+      Value: "CrowdPowered",
+    },
   ]);
-
 }
 
 export function validateEnvironmentVariables(...variables: string[]) {
-  const missingVariables = variables.filter(variable => !process.env[variable]);
+  const missingVariables = variables.filter(
+    (variable) => !process.env[variable]
+  );
 
   if (missingVariables.length > 0) {
-    throw new Error(`Missing environment variables: ${missingVariables.join(', ')}`);
+    throw new Error(
+      `Missing environment variables: ${missingVariables.join(", ")}`
+    );
   }
 }

--- a/projects/code-from-asset-helper/tests/utils.fail.resolver.ts
+++ b/projects/code-from-asset-helper/tests/utils.fail.resolver.ts
@@ -1,0 +1,4 @@
+export async function addition(a: number, b: number): Promise<number> {
+  const c = 12;
+  return a + b;
+}

--- a/projects/code-from-asset-helper/tsconfig.json
+++ b/projects/code-from-asset-helper/tsconfig.json
@@ -1,10 +1,11 @@
 {
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "include": ["**/*.ts", "**/*.mjs", "eslint.config.mjs"],
   "compilerOptions": {
-    "types": [
-      "node"
-    ],
-    "target": "ES2020",
-    "module": "commonjs",
+    "types": ["node"],
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "declaration": true,
     "outDir": "./dist",
     "esModuleInterop": true,


### PR DESCRIPTION

This pull request includes several changes to improve the codebase and documentation for the `code-from-asset-helper` project. The most important changes include:

1. the upgrade of eslint from v8 to v9.
2. perform linting of nested files
3. defer lint config to the project's eslint config file

### Documentation Updates:
* [`projects/code-from-asset-helper/README.md`](diffhunk://#diff-423a52f767df2f9f2943b49db1bd913e6aae35e05ee066c47d86ffdd7a101d8bL9-L45): Updated import statements to use double quotes and added a new section on linting configuration for both Lambda and AppSync environments. [[1]](diffhunk://#diff-423a52f767df2f9f2943b49db1bd913e6aae35e05ee066c47d86ffdd7a101d8bL9-L45) [[2]](diffhunk://#diff-423a52f767df2f9f2943b49db1bd913e6aae35e05ee066c47d86ffdd7a101d8bL54-R264)

### ESLint Configuration Enhancements:
* [`projects/code-from-asset-helper/eslint.config.mjs`](diffhunk://#diff-ecce5af2012593f7abe564b1588c58fe4cbdb4b2cef8cecb7ed0e608ca608fb3R1-R68): Updated ESLint configuration to use `typescript-eslint` and `@aws-appsync/eslint-plugin`, and added new rules to restrict imports between Lambda and AppSync files.

### Backend Utility Improvements:
* [`projects/code-from-asset-helper/lib/backend.utils.ts`](diffhunk://#diff-a2a26765e1c79669f8fa730746f13af3164159ce876dacf063afde55a2dd754cR12-R13): Added error handling, updated the `esbuildBuilding` function to return nested local imports, and enhanced the `esLinting` function to support both file and text inputs. [[1]](diffhunk://#diff-a2a26765e1c79669f8fa730746f13af3164159ce876dacf063afde55a2dd754cR12-R13) [[2]](diffhunk://#diff-a2a26765e1c79669f8fa730746f13af3164159ce876dacf063afde55a2dd754cL22-R27) [[3]](diffhunk://#diff-a2a26765e1c79669f8fa730746f13af3164159ce876dacf063afde55a2dd754cR44-R45) [[4]](diffhunk://#diff-a2a26765e1c79669f8fa730746f13af3164159ce876dacf063afde55a2dd754cR128-R136) [[5]](diffhunk://#diff-a2a26765e1c79669f8fa730746f13af3164159ce876dacf063afde55a2dd754cR181-R183) [[6]](diffhunk://#diff-a2a26765e1c79669f8fa730746f13af3164159ce876dacf063afde55a2dd754cL263-L321) [[7]](diffhunk://#diff-a2a26765e1c79669f8fa730746f13af3164159ce876dacf063afde55a2dd754cR382-R434) [[8]](diffhunk://#diff-a2a26765e1c79669f8fa730746f13af3164159ce876dacf063afde55a2dd754cL349-L381) [[9]](diffhunk://#diff-a2a26765e1c79669f8fa730746f13af3164159ce876dacf063afde55a2dd754cL409-R490)